### PR TITLE
perf: reduce allocations in `MediaType::from_specifier`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.71.1"
+channel = "1.77.1"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,6 +218,8 @@ impl MediaType {
         }
       },
       Some(ext) => {
+        // using eq_ignore_ascii_case with if/elses seems to be ~40ns
+        // slower here, so continue to use to_lowercase()
         let lowercase_str = ext.to_lowercase();
         match lowercase_str.as_str() {
           "ts" => map_typescript_like(path, Self::TypeScript, Self::Dts),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 // Copyright 2018-2023 the Deno authors. All rights reserved. MIT license.
 
+#![deny(clippy::print_stderr)]
+#![deny(clippy::print_stdout)]
+
 use serde::Serialize;
 use serde::Serializer;
 use std::fmt;
@@ -216,7 +219,6 @@ impl MediaType {
       },
       Some(ext) => {
         let lowercase_str = ext.to_lowercase();
-        eprintln!("STR: {}", lowercase_str);
         match lowercase_str.as_str() {
           "ts" => map_typescript_like(path, Self::TypeScript, Self::Dts),
           "mts" => map_typescript_like(path, Self::Mts, Self::Dmts),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,10 +210,10 @@ impl MediaType {
       None => match path.file_name() {
         None => Self::Unknown,
         Some(file_name) => {
-          let lowercase_str = file_name.to_lowercase();
-          match lowercase_str.as_str() {
-            ".tsbuildinfo" => Self::TsBuildInfo,
-            _ => Self::Unknown,
+          if file_name.eq_ignore_ascii_case(".tsbuildinfo") {
+            Self::TsBuildInfo
+          } else {
+            Self::Unknown
           }
         }
       },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -727,6 +727,7 @@ mod tests {
     assert_eq!(MediaType::Unknown.to_string(), "Unknown");
   }
 
+  #[cfg(feature = "module_specifier")]
   #[test]
   fn test_url_path_like_file_stem() {
     let url = ModuleSpecifier::parse("file:///.test").unwrap();
@@ -737,6 +738,7 @@ mod tests {
     assert_eq!((&url).file_stem(), None);
   }
 
+  #[cfg(feature = "module_specifier")]
   #[test]
   fn test_url_path_like_extension() {
     let url = ModuleSpecifier::parse("file:///.test").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,11 +166,14 @@ impl MediaType {
     specifier: &ModuleSpecifier,
     content_type: S,
   ) -> Self {
-    match content_type.as_ref().split(';').collect::<Vec<&str>>()[0]
-      .trim()
-      .to_lowercase()
+    let first_part = content_type
       .as_ref()
-    {
+      .split(';')
+      .next()
+      .unwrap()
+      .trim()
+      .to_lowercase();
+    match first_part.as_str() {
       "application/typescript"
       | "text/typescript"
       | "video/vnd.dlna.mpeg-tts"


### PR DESCRIPTION
This is used a lot in the node resolution.

```
test tests::from_specifier     ... bench:         199 ns/iter (+/- 17)
test tests::from_specifier_old ... bench:         342 ns/iter (+/- 11)
```