### PR TITLE
fix: correct Wasm ts extension

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ impl MediaType {
       // TypeScript doesn't have an "unknown", so we will treat WASM as JS for
       // mapping purposes, though in reality, it is unlikely to ever be passed
       // to the compiler.
-      Self::Wasm => ".js",
+      Self::Wasm => ".d.mts",
       // TypeScript doesn't have an "source map", so we will treat SourceMap as
       // JS for mapping purposes, though in reality, it is unlikely to ever be
       // passed to the compiler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,7 @@ impl MediaType {
       Self::Tsx => ".tsx",
       Self::Css => ".css",
       Self::Json => ".json",
-      // TypeScript doesn't have an "unknown", so we will treat WASM as JS for
-      // mapping purposes, though in reality, it is unlikely to ever be passed
-      // to the compiler.
+      // We transform Wasm to a declaration file.
       Self::Wasm => ".d.mts",
       // TypeScript doesn't have an "source map", so we will treat SourceMap as
       // JS for mapping purposes, though in reality, it is unlikely to ever be


### PR DESCRIPTION
We treat Wasm modules as an ESM declaration file.