### PR TITLE
chore: update rust version

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.77.1"
+channel = "1.85.0"
 components = ["clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
Currently the publishing is blocked by the rust version. https://github.com/denoland/deno_media_type/actions/runs/13691704800/job/38285983023